### PR TITLE
Add feature to just use in-memory data

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ $test->input('Book1.xlsx')
     ->output('bb.xlsx');
 ```
 
+
+If you want to only use memory/variable output and input, and no file interaction
+```php
+$test = new Encrypt($nofile = true);
+$output = $test->input($binaryData)
+    ->password('111')
+    ->output();
+```
+
 ## Credits
 
 Thanks to [xlsx-populate](https://github.com/dtjohnson/xlsx-populate) for providing the encryption and password protection.


### PR DESCRIPTION
Adds a feature to use only in-memory data, in some flows it is better to avoid cycles of reading/writing to files, and it is faster to just use in-memory usually.

Haven't profiled the code, but should be okay

Also Updated the Documentation
